### PR TITLE
feat: add node types clustering

### DIFF
--- a/packages/compendium-ui/package.json
+++ b/packages/compendium-ui/package.json
@@ -26,11 +26,8 @@
     "./dist/style.css": "./dist/style.css"
   },
   "dependencies": {
+    "@ant-design/icons": "^5.1.4",
     "@apollo/client": "^3.7.1",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
-    "react-router-dom": "^6.3.0",
-    "@lifeomic/react-vis-network": "^1.1.0",
     "antd": "^4.23.6",
     "aws-appsync": "^4.1.5",
     "aws-appsync-auth-link": "^3.0.7",
@@ -39,6 +36,11 @@
     "graphql": "^15.8.0",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.40",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-graph-vis": "^1.0.7",
+    "react-router-dom": "^6.3.0",
+    "string-hash": "^1.1.3",
     "vis-data": "^7.1.4",
     "vis-network": "^9.1.2",
     "vis-react": "^0.5.1"
@@ -52,6 +54,8 @@
     "@types/node": "^16.11.27",
     "@types/react": "^18.0.5",
     "@types/react-dom": "^18.0.1",
+    "@types/string-hash": "^1.1.1",
+    "@types/uuid": "^9.0.2",
     "@vitejs/plugin-react": "^3.0.1",
     "c8": "^7.12.0",
     "eslint": "^8.33.0",

--- a/packages/compendium-ui/src/lib/@types/react-graph-vis/typings.d.ts
+++ b/packages/compendium-ui/src/lib/@types/react-graph-vis/typings.d.ts
@@ -1,0 +1,1 @@
+declare module "react-graph-vis";

--- a/packages/compendium-ui/src/lib/App.tsx
+++ b/packages/compendium-ui/src/lib/App.tsx
@@ -1,19 +1,24 @@
 import { Layout } from "antd";
 import "./App.css";
-
 import { IndexPage } from "./pages/Index";
+import { Settings } from "./components/settings";
+import { SettingsContext } from "./contexts/settings";
+import { useState } from "react";
 
 function App() {
+  const [settings, setSettings] = useState({
+    clusteringEnabled: true,
+  });
+
   return (
-    <Layout style={{ height: "100%" }}>
-      {/* <Layout.Header>aaa</Layout.Header> */}
-      {/* <Layout>
-        <Layout.Sider theme="light">aaa</Layout.Sider> */}
-      <Layout.Content>
-        <IndexPage />
-      </Layout.Content>
-      {/* </Layout> */}
-    </Layout>
+    <SettingsContext.Provider value={{ settings, setSettings }}>
+      <Settings />
+      <Layout style={{ height: "100%" }}>
+        <Layout.Content>
+          <IndexPage />
+        </Layout.Content>
+      </Layout>
+    </SettingsContext.Provider>
   );
 }
 

--- a/packages/compendium-ui/src/lib/components/diagram/index.tsx
+++ b/packages/compendium-ui/src/lib/components/diagram/index.tsx
@@ -1,6 +1,11 @@
+import { pickTextColorBasedOnBgColor } from "../../helpers/colors.helper";
+import {
+  getNodeTypesColorMap,
+  getUniqueTypes,
+} from "../../helpers/node.helper";
 import { Node } from "../../queries/query-node";
 import { useQueryNodes } from "../../queries/query-nodes";
-import { DataEdge, DiagramNetwork } from "./network";
+import { DataEdge, DataNode, DiagramNetwork } from "./network";
 
 interface DiagramProps {
   nodeIds: string[];
@@ -12,57 +17,92 @@ export const Diagram = (props: DiagramProps) => {
   const { nodeIds, selectedNodeId, nodeSelected } = props;
   const { data } = useQueryNodes({ ids: nodeIds });
 
-  const nodes = {} as { [key: string]: Node };
+  const allNodes =
+    data?.filter((n) => n).flatMap((baseNode) => [
+      ...baseNode.dependencies.map((n: any) => n.node),
+      ...baseNode.dependants.map((n: any) => n.node),
+      baseNode,
+    ]) || [];
+
+  const typesColorMap = getNodeTypesColorMap(allNodes);
+  const uniqueTypes = getUniqueTypes(allNodes);
+
+  const getNodeProperties = (
+    node: Node,
+    typesColorMap: Record<string, string>
+  ) => {
+    const nodeBgColor = typesColorMap[node.type.id];
+
+    const nodeFontColor = nodeBgColor
+      ? pickTextColorBasedOnBgColor(nodeBgColor, "#FFFFFF", "#000000")
+      : "#FFFFFF";
+    const borderWidth = nodeIds.indexOf(node.id) === -1 ? 1 : 3;
+
+    return {
+      id: node.id,
+      label: node.name,
+      color: nodeBgColor,
+      font: {
+        color: nodeFontColor,
+      },
+      type: node.type.id,
+      borderWidth,
+    };
+  };
+
+  const nodes = {} as { [key: string]: DataNode };
   const edges = {} as { [key: string]: DataEdge };
+
   if (data) {
     for (const node of data) {
       if (!node) {
         continue;
       }
-      nodes[node.id] = node;
+      nodes[node.id] = getNodeProperties(node, typesColorMap);
 
       for (const d of node.dependencies) {
         if (!d.node) continue;
         const dn = d.node;
         const from = node.id;
         const to = dn.id;
-        const id = `${from}_${to}`;
-        edges[id] = { from, to, id, length: 200, dashed: false };
-        nodes[dn.id] = dn;
+        const edgeId = `${from}_${to}`;
+        const nodeProperties = getNodeProperties(dn, typesColorMap);
+        edges[edgeId] = { from, to, id: edgeId, length: 200, dashes: false };
+        nodes[dn.id] = nodeProperties;
       }
       for (const d of node.dependants) {
         if (!d.node) continue;
         const dn = d.node;
-
         const to = node.id;
         const from = dn.id;
-        const id = `${from}_${to}`;
-        edges[id] = {
+        const edgeId = `${from}_${to}`;
+        const nodeProperties = getNodeProperties(dn, typesColorMap);
+
+        edges[edgeId] = {
           from,
           to,
-          id,
+          id: edgeId,
           length: 200,
-          dashed: false, //d.dependantVersion !== dn.version,
+          dashes: false, //d.dependantVersion !== dn.version,
         };
-        nodes[dn.id] = dn;
+        nodes[dn.id] = nodeProperties;
       }
     }
   }
-  const graph = { nodes, edges };
+  const graph = {
+    nodes: Object.values(nodes).map((n) => n),
+    edges: Object.values(edges).map((e) => e),
+  };
 
   return (
     <>
-      {/* {JSON.stringify(graph, null, "")} */}
-      {/* {JSON.stringify(data, null, "")} */}
-
       <DiagramNetwork
         selectedNodeIds={selectedNodeId ? [selectedNodeId] : []}
         visibleNodeIds={nodeIds}
-        // selectedNodeIds={[]}
-        // visibleNodeIds={[]}
+        typesColorMap={typesColorMap}
+        uniqueTypes={uniqueTypes}
         graph={graph}
         nodeSelected={(node, shift) => {
-          // setNode(node);
           if (nodeSelected) {
             nodeSelected(node, shift);
           }

--- a/packages/compendium-ui/src/lib/components/node-detail-drawer-nodes.tsx
+++ b/packages/compendium-ui/src/lib/components/node-detail-drawer-nodes.tsx
@@ -1,0 +1,91 @@
+import { Badge, Collapse, Input, List, Typography } from "antd";
+import { groupByNodeType } from "../helpers/node.helper";
+import { Node } from "../queries/query-node";
+import { useState } from "react";
+
+interface NodeDetailDrawerProps {
+  inputNodes: Node[];
+  panelKey: string;
+  header: string;
+  searchPlaceholder: string;
+  typesColorMap: Record<string, string>;
+  onClose: () => void;
+  onNodeSelected: (id: string) => void;
+}
+export const NodeDetailDrawerNodes = ({
+  inputNodes,
+  panelKey,
+  header,
+  searchPlaceholder,
+  typesColorMap,
+  onNodeSelected,
+}: NodeDetailDrawerProps) => {
+  const [searchQuery, setSearchQuery] = useState("");
+  let nodes = [...inputNodes];
+
+  if (searchQuery) {
+    nodes = nodes.filter(
+      (d) =>
+        d.name.indexOf(searchQuery) !== -1 || d.id.indexOf(searchQuery) !== -1
+    );
+  }
+
+  const handleSearchInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setSearchQuery(event.target.value.toLowerCase());
+  };
+
+  return (
+    <>
+      {nodes && (
+        <Collapse>
+          <Collapse.Panel key={panelKey} header={header}>
+            <Input
+              placeholder={searchPlaceholder}
+              style={{ marginBottom: "5px" }}
+              onChange={(event) => {
+                handleSearchInputChange(event);
+              }}
+            />
+            {nodes && (
+              <Collapse>
+                {Object.entries(groupByNodeType(nodes)).map(
+                  ([typeId, nodes]) => (
+                    <Collapse.Panel
+                      key={typeId}
+                      header={
+                        <>
+                          {typeId}{" "}
+                          <Badge
+                            count={nodes.length}
+                            className="site-badge-count-109"
+                            style={{ backgroundColor: typesColorMap[typeId] }}
+                          />
+                        </>
+                      }
+                    >
+                      <List
+                        dataSource={nodes}
+                        renderItem={(i) => (
+                          <List.Item key={i.id}>
+                            <Typography.Link
+                              href="#"
+                              onClick={() => onNodeSelected(i.id)}
+                            >
+                              {i.name}
+                            </Typography.Link>
+                          </List.Item>
+                        )}
+                      ></List>
+                    </Collapse.Panel>
+                  )
+                )}
+              </Collapse>
+            )}
+          </Collapse.Panel>
+        </Collapse>
+      )}
+    </>
+  );
+};

--- a/packages/compendium-ui/src/lib/components/settings.tsx
+++ b/packages/compendium-ui/src/lib/components/settings.tsx
@@ -1,0 +1,72 @@
+import {
+  CheckOutlined,
+  CloseOutlined,
+  InfoCircleOutlined,
+  SettingOutlined,
+} from "@ant-design/icons";
+import { Affix, Button, List, Popover, Space, Switch, Typography } from "antd";
+import { SettingsContext } from "../contexts/settings";
+import { useContext } from "react";
+
+export const Settings = () => {
+  const { settings, setSettings } = useContext(SettingsContext);
+
+  const handleChange = (enabled: boolean) => {
+    setSettings({ clusteringEnabled: enabled });
+  };
+  return (
+    <Affix style={{ zIndex: 1000, position: "absolute", top: 30, left: 30 }}>
+      <div>
+        <Popover
+          content={
+            <List bordered>
+              <List.Item>
+                <Typography.Text mark>click on the node</Typography.Text> -
+                select specific node
+              </List.Item>
+              <List.Item>
+                <Typography.Text mark>
+                  shift + click on the node
+                </Typography.Text>{" "}
+                - select another node
+              </List.Item>
+              <List.Item>
+                <Typography.Text mark>
+                  double-click on the cluster
+                </Typography.Text>{" "}
+                - open cluster
+              </List.Item>
+            </List>
+          }
+          trigger="click"
+        >
+          <div>
+            <Button>
+              <InfoCircleOutlined rev={undefined} />
+            </Button>
+          </div>
+        </Popover>
+        <Popover
+          content={
+            <Space direction="vertical">
+              <Switch
+                checkedChildren={<CheckOutlined rev={undefined} />}
+                unCheckedChildren={<CloseOutlined rev={undefined} />}
+                onChange={(enabled) => handleChange(enabled)}
+                defaultChecked={settings.clusteringEnabled}
+              />{" "}
+              enable clustering
+            </Space>
+          }
+          trigger="click"
+        >
+          <div>
+            <Button>
+              <SettingOutlined rev={undefined} />
+            </Button>
+          </div>
+        </Popover>
+      </div>
+    </Affix>
+  );
+};

--- a/packages/compendium-ui/src/lib/contexts/settings.ts
+++ b/packages/compendium-ui/src/lib/contexts/settings.ts
@@ -1,0 +1,17 @@
+import { createContext } from "react";
+
+interface SettingsContext {
+  settings: Settings;
+  setSettings: (value: Settings) => void;
+}
+
+interface Settings {
+  clusteringEnabled: boolean;
+}
+
+const SettingsContext = createContext<SettingsContext>({
+  settings: { clusteringEnabled: true },
+  setSettings: () => {},
+});
+
+export { SettingsContext };

--- a/packages/compendium-ui/src/lib/helpers/colors.helper.ts
+++ b/packages/compendium-ui/src/lib/helpers/colors.helper.ts
@@ -1,0 +1,19 @@
+export function pickTextColorBasedOnBgColor(
+  bgColor: string,
+  lightColor: string,
+  darkColor: string
+) {
+  var color = bgColor.charAt(0) === "#" ? bgColor.substring(1, 7) : bgColor;
+  var r = parseInt(color.substring(0, 2), 16); // hexToR
+  var g = parseInt(color.substring(2, 4), 16); // hexToG
+  var b = parseInt(color.substring(4, 6), 16); // hexToB
+  var uicolors = [r / 255, g / 255, b / 255];
+  var c = uicolors.map((col) => {
+    if (col <= 0.03928) {
+      return col / 12.92;
+    }
+    return Math.pow((col + 0.055) / 1.055, 2.4);
+  });
+  var L = 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+  return L > 0.179 ? darkColor : lightColor;
+}

--- a/packages/compendium-ui/src/lib/helpers/node.helper.ts
+++ b/packages/compendium-ui/src/lib/helpers/node.helper.ts
@@ -1,0 +1,35 @@
+import stringHash from "string-hash";
+import { Node } from "../queries/query-node";
+
+export const groupByNodeType = (array: Node[]) =>
+  array.reduce<Record<string, Node[]>>(
+    (grouped, element) => ({
+      ...grouped,
+      [element.type.id]: [...(grouped[element.type.id] || []), element],
+    }),
+    {}
+  );
+
+export function getUniqueTypes<T>(
+  nodes: (T & { type: { id: string } })[]
+): string[] {
+  const uniqueValues: string[] = [];
+
+  nodes.forEach((node) => {
+    if (node && node.type && node.type.id && !uniqueValues.includes(node.type.id)) {
+      uniqueValues.push(node.type.id);
+    }
+  });
+
+  return uniqueValues;
+}
+
+export function getNodeTypesColorMap(nodes: Node[]) {
+  const uniqueTypes = getUniqueTypes(nodes || []);
+  const colorMap: Record<string, string> = {};
+  uniqueTypes.forEach((type) => {
+    const color = "#" + stringHash(type).toString(16).slice(0, 6);
+    colorMap[type] = color;
+  });
+  return colorMap;
+}

--- a/packages/compendium-ui/src/lib/queries/query-node.ts
+++ b/packages/compendium-ui/src/lib/queries/query-node.ts
@@ -8,6 +8,11 @@ export interface Depend {
 interface NodeMetadata {
   description: string;
 }
+
+interface Type {
+  id: string;
+  name: string;
+}
 export interface Node {
   id: string;
   name: string;
@@ -15,6 +20,7 @@ export interface Node {
   version: string;
   dependencies: Depend[];
   dependants: Depend[];
+  type: Type;
 }
 export type QueryNodeResult = { node?: Node };
 
@@ -29,12 +35,20 @@ export const QUERY_NODE = gql`
         ${metadataFields}
       }
       version
+      type {
+        id
+        name
+      }
       dependencies {
         dependantVersion
         node {
           id
           name
           version
+          type {
+            id
+            name
+          }
           metadata {
             ${metadataFields}
           }
@@ -45,6 +59,10 @@ export const QUERY_NODE = gql`
         node {
           id
           name
+          type {
+            id
+            name
+          }
           metadata {
             ${metadataFields}
           }

--- a/packages/compendium-ui/src/lib/queries/query-nodes.ts
+++ b/packages/compendium-ui/src/lib/queries/query-nodes.ts
@@ -13,6 +13,10 @@ node${i}:node(id: $id${i}) {
     ${metadataFields}
   }
   version
+  type {
+    id
+    name
+  }
   dependencies {
     dependantVersion
     node {
@@ -21,6 +25,10 @@ node${i}:node(id: $id${i}) {
       version
       metadata {
         ${metadataFields}
+      }
+      type {
+        id
+        name
       }
     }
   }
@@ -31,6 +39,10 @@ node${i}:node(id: $id${i}) {
       name
       metadata {
         ${metadataFields}
+      }
+      type {
+        id
+        name
       }
     }
   }


### PR DESCRIPTION
- change graph library from https://github.com/lifeomic/react-vis-network to  https://www.npmjs.com/package/react-graph-vis ( previous library is now deprecated)
- added node clustering by node types (updated graph network and detail drawer)
- added global context with settings
- added help