### PR TITLE
feat(compendium-ui): modify graph events

### DIFF
--- a/packages/compendium-ui/src/lib/components/diagram/index.tsx
+++ b/packages/compendium-ui/src/lib/components/diagram/index.tsx
@@ -10,7 +10,11 @@ import { DataEdge, DataNode, DiagramNetwork } from "./network";
 interface DiagramProps {
   nodeIds: string[];
   selectedNodeId?: string;
-  nodeSelected?: (node: string, shift: boolean) => void;
+  nodeSelected?: (
+    node: string,
+    shift: boolean,
+    resetVisibleNodes: boolean
+  ) => void;
 }
 
 export const Diagram = (props: DiagramProps) => {
@@ -18,11 +22,13 @@ export const Diagram = (props: DiagramProps) => {
   const { data } = useQueryNodes({ ids: nodeIds });
 
   const allNodes =
-    data?.filter((n) => n).flatMap((baseNode) => [
-      ...baseNode.dependencies.map((n: any) => n.node),
-      ...baseNode.dependants.map((n: any) => n.node),
-      baseNode,
-    ]) || [];
+    data
+      ?.filter((n) => n)
+      .flatMap((baseNode) => [
+        ...baseNode.dependencies.map((n: any) => n.node),
+        ...baseNode.dependants.map((n: any) => n.node),
+        baseNode,
+      ]) || [];
 
   const typesColorMap = getNodeTypesColorMap(allNodes);
   const uniqueTypes = getUniqueTypes(allNodes);
@@ -102,9 +108,9 @@ export const Diagram = (props: DiagramProps) => {
         typesColorMap={typesColorMap}
         uniqueTypes={uniqueTypes}
         graph={graph}
-        nodeSelected={(node, shift) => {
+        nodeSelected={(node, shift, resetVisibleNodes) => {
           if (nodeSelected) {
-            nodeSelected(node, shift);
+            nodeSelected(node, shift, resetVisibleNodes);
           }
         }}
       />

--- a/packages/compendium-ui/src/lib/components/diagram/network.tsx
+++ b/packages/compendium-ui/src/lib/components/diagram/network.tsx
@@ -34,7 +34,11 @@ interface DiagramNetworkProps {
   typesColorMap: Record<string, string>;
   uniqueTypes: string[];
   graph: Graph;
-  nodeSelected?: (node: string, shift: boolean) => void;
+  nodeSelected?: (
+    node: string,
+    shift: boolean,
+    resetVisibleNodes: boolean
+  ) => void;
 }
 
 export const DiagramNetwork = (props: DiagramNetworkProps) => {
@@ -81,7 +85,13 @@ export const DiagramNetwork = (props: DiagramNetworkProps) => {
           getNetwork={(network: any) => {
             network.on("click", (params: any) => {
               if (nodeSelected && params.nodes[0]) {
-                nodeSelected(params.nodes[0], params.event.srcEvent.shiftKey);
+                const isShiftKeyPressed = params.event.srcEvent.shiftKey;
+                const resetVisibleNodes = false;
+                nodeSelected(
+                  params.nodes[0],
+                  isShiftKeyPressed,
+                  resetVisibleNodes
+                );
               }
             });
 
@@ -89,6 +99,14 @@ export const DiagramNetwork = (props: DiagramNetworkProps) => {
               if (params.nodes.length == 1) {
                 if (network.isCluster(params.nodes[0]) == true) {
                   network.openCluster(params.nodes[0]);
+                } else if (nodeSelected) {
+                  const resetVisibleNodes = true;
+                  const isShiftKeyPressed = false;
+                  nodeSelected(
+                    params.nodes[0],
+                    isShiftKeyPressed,
+                    resetVisibleNodes
+                  );
                 }
               }
             });

--- a/packages/compendium-ui/src/lib/components/settings.tsx
+++ b/packages/compendium-ui/src/lib/components/settings.tsx
@@ -22,13 +22,23 @@ export const Settings = () => {
             <List bordered>
               <List.Item>
                 <Typography.Text mark>click on the node</Typography.Text> -
-                select specific node
+                focus specific node (open drawer on the right side)
+              </List.Item>
+              <List.Item>
+                <Typography.Text mark>double-click on the node</Typography.Text> -
+                select specific node (this will reset all previous selection)
               </List.Item>
               <List.Item>
                 <Typography.Text mark>
                   shift + click on the node
                 </Typography.Text>{" "}
                 - select another node
+              </List.Item>
+              <List.Item>
+                <Typography.Text mark>
+                  shift + click on the already selected node
+                </Typography.Text>{" "}
+                - unselect node
               </List.Item>
               <List.Item>
                 <Typography.Text mark>

--- a/packages/compendium-ui/src/lib/pages/Index.tsx
+++ b/packages/compendium-ui/src/lib/pages/Index.tsx
@@ -64,12 +64,38 @@ export const IndexPage = () => {
           // key={JSON.stringify(selection)}
           nodeIds={selection.visibleNodes}
           selectedNodeId={selection.selectedNode}
-          nodeSelected={(id, shift) => {
+          nodeSelected={(id, shift, resetVisibleNodes) => {
+            // If `resetVisibleNodes` is true, it will set only currently selected node as visible
+            if (resetVisibleNodes) {
+              setNodeSelection({
+                selectedNode: id,
+                visibleNodes: [id],
+              });
+              return;
+            }
+
+            let newVisibleNodes = [...(selection.visibleNodes || [])];
+
+            //  If shift key is not pressed, simply select the node
+            if (!shift) {
+              setNodeSelection({
+                selectedNode: id,
+                visibleNodes: newVisibleNodes,
+              });
+              return;
+            }
+
+            // If we want another node to be visible but this node has been already selected - unselect it
+            const nodeIsAlreadyVisible = newVisibleNodes.indexOf(id) !== -1;
+            if (nodeIsAlreadyVisible) {
+              newVisibleNodes = newVisibleNodes.filter((n) => n !== id);
+            } else {
+              newVisibleNodes = [id, ...newVisibleNodes];
+            }
+
             setNodeSelection({
               selectedNode: id,
-              visibleNodes: shift
-                ? [id, ...(selection.visibleNodes || [])]
-                : selection.visibleNodes,
+              visibleNodes: newVisibleNodes,
             });
           }}
         />


### PR DESCRIPTION
- updated graph help
- you can now double-click on the node - it will reset all selections
- you can now unselect already selected node 